### PR TITLE
Minor fix correcting sizeof() call

### DIFF
--- a/gs_patterns_core.cpp
+++ b/gs_patterns_core.cpp
@@ -163,7 +163,7 @@ namespace gs_patterns_core
                     fprintf(fp, ",\n {\"kernel\":\"%s\", \"pattern\":[", target_metrics.getName().c_str());
                 }
 
-                fwrite(target_metrics.patterns[i], sizeof(uint64_t), target_metrics.offset[i], fp_bin);
+                fwrite(target_metrics.patterns[i], sizeof(int64_t), target_metrics.offset[i], fp_bin);
                 fclose(fp_bin);
 
                 for (j = 0; j < target_metrics.offset[i] - 1; j++)


### PR DESCRIPTION
The function that creates the metrics file calls fwrite().

It pass to fwrite() a pointer pointing to the data to be written. This pointer is stored inside the patterns[] array of the Metrics object.

The next argument passed to fwrite is the size of the data to be written.

This is supposed to be sizeof(int64_t), not sizeof(uint64_t).

The correction is important because there may be differences between the two sizes depending on the platform.