### PR TITLE
Fix: Correctly apply trace pattern filters for report generation

### DIFF
--- a/gs_patterns_core.cpp
+++ b/gs_patterns_core.cpp
@@ -80,8 +80,14 @@ namespace gs_patterns_core
 
             outbounds = (double) (n_stride[0] + n_stride[OBOUNDS_ALLOC-1]) / (double) target_metrics.offset[i];
 
-            if (((unique_strides > NSTRIDES) || (outbounds > OUTTHRESH)  && (target_metrics.offset[i] > USTRIDES ) )) {
-		//if (true) {
+            bool has_too_few_instances = (target_metrics.offset[i] < USTRIDES ); // FILTER 4 ("Less than 1024 instances")
+            bool is_not_complex = (unique_strides < NSTRIDES);  // FILTER 5 ("Less than 6 unique index distances...
+            bool is_not_out_of_bounds = (outbounds < OUTTHRESH); // FILTER 5 ...and less than 50% out of bounds distances")
+            bool exclude = (
+                    (has_too_few_instances) || (is_not_complex && is_not_out_of_bounds)
+                ); // Fails Filter 4 or fails Filter 5
+
+            if (!exclude) {
 
 	        if (firstgs) {
 	  	  firstgs = 0;


### PR DESCRIPTION
Fix a logical discrepancy in gs_patterns_core.cpp that caused insignificant trace patterns to be incorrectly included in the final report files.

The if condition in the create_metrics_file function, which decides whether to include a pattern, had an operator precedence error.

Old logic:

```C++
// This was evaluated as if (A || (B && C))
if (((unique_strides > NSTRIDES) || (outbounds > OUTTHRESH) && (target_metrics.offset[i] > USTRIDES ) ))
```

This meant that a pattern was included if it was "complex" (many unique distances) OR if it was "out of bounds" AND "significant" (had many instances). The problem is that a pattern that was "complex" but not "significant" would still be included, which is not the intended behavior.

I refactored the logic to use named boolean variables that directly correspond to the filter rules described in the project documentation (specifically Filter 4 and Filter 5).

New (correct) logic:

```C++
bool has_too_few_instances = (target_metrics.offset[i] < USTRIDES ); // FILTER 4 ("Less than 1024 instances")
bool is_not_complex = (unique_strides < NSTRIDES);  // FILTER 5 ("Less than 6 unique index distances...
bool is_not_out_of_bounds = (outbounds < OUTTHRESH); // FILTER 5 ...and less than 50% out of bounds distances)
bool exclude = (
        (has_too_few_instances) || (is_not_complex && is_not_out_of_bounds)
    ); // Fails Filter 4 or fails Filter 5

if (!exclude) {
  // ... include pattern in report
}
```
This enforces the intended logic from the paper ("A Workflow for the Synthesis of Irregular Memory Access Microbenchmarks"): a pattern is only included if it passes both Filter 4 AND Filter 5.

<img width="789" height="388" alt="image" src="https://github.com/user-attachments/assets/17daf0b9-e070-4d89-95ed-a4f22ddd479e" />
